### PR TITLE
fix: 안드로이드 gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,80 +1,17 @@
 plugins {
-  id 'com.android.application'
-  id 'org.jetbrains.kotlin.android'
-  id 'com.facebook.react'
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("com.facebook.react")
 
-  // Firebase 문서에서 추가하라고 한 플러그인
-  id 'com.google.gms.google-services'
+    // Firebase Google Services Plugin
+    id("com.google.gms.google-services")
 }
 
-/**
- * This is the configuration block to customize your React Native Android app.
- * By default you don't need to apply any configuration, just uncomment the lines you need.
- */
 react {
-    /* Folders */
-    //   The root of your project, i.e. where "package.json" lives. Default is '../..'
-    // root = file("../../")
-    //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
-    // reactNativeDir = file("../../node_modules/react-native")
-    //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen
-    // codegenDir = file("../../node_modules/@react-native/codegen")
-    //   The cli.js file which is the React Native CLI entrypoint. Default is ../../node_modules/react-native/cli.js
-    // cliFile = file("../../node_modules/react-native/cli.js")
-
-    /* Variants */
-    //   The list of variants to that are debuggable. For those we're going to
-    //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
-    //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
-    // debuggableVariants = ["liteDebug", "prodDebug"]
-
-    /* Bundling */
-    //   A list containing the node command and its flags. Default is just 'node'.
-    // nodeExecutableAndArgs = ["node"]
-    //
-    //   The command to run when bundling. By default is 'bundle'
-    // bundleCommand = "ram-bundle"
-    //
-    //   The path to the CLI configuration file. Default is empty.
-    // bundleConfig = file(../rn-cli.config.js)
-    //
-    //   The name of the generated asset file containing your JS bundle
-    // bundleAssetName = "MyApplication.android.bundle"
-    //
-    //   The entry file for bundle generation. Default is 'index.android.js' or 'index.js'
-    // entryFile = file("../js/MyApplication.android.js")
-    //
-    //   A list of extra flags to pass to the 'bundle' commands.
-    //   See https://github.com/react-native-community/cli/blob/main/docs/commands.md#bundle
-    // extraPackagerArgs = []
-
-    /* Hermes Commands */
-    //   The hermes compiler command to run. By default it is 'hermesc'
-    // hermesCommand = "$rootDir/my-custom-hermesc/bin/hermesc"
-    //
-    //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
-    // hermesFlags = ["-O", "-output-source-map"]
-
-    /* Autolinking */
     autolinkLibrariesWithApp()
 }
 
-/**
- * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
- */
 def enableProguardInReleaseBuilds = false
-
-/**
- * The preferred build flavor of JavaScriptCore (JSC)
- *
- * For example, to use the international variant, you can use:
- * `def jscFlavor = io.github.react-native-community:jsc-android-intl:2026004.+`
- *
- * The international variant includes ICU i18n library and necessary data
- * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
- * give correct results when using with locales other than en-US. Note that
- * this variant is about 6MiB larger per architecture than default.
- */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
 android {
@@ -83,6 +20,7 @@ android {
     compileSdk rootProject.ext.compileSdkVersion
 
     namespace "com.toylink"
+
     defaultConfig {
         applicationId "com.toylink"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -90,6 +28,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
     signingConfigs {
         debug {
             storeFile file('debug.keystore')
@@ -98,22 +37,23 @@ android {
             keyPassword 'android'
         }
     }
+
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
         }
         release {
-            // Caution! In production, you need to generate your own keystore file.
-            // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles(
+                    getDefaultProguardFile("proguard-android.txt"),
+                    "proguard-rules.pro"
+            )
         }
     }
 }
 
 dependencies {
-    // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
     if (hermesEnabled.toBoolean()) {
@@ -122,6 +62,9 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation platform('com.google.firebase:firebase-bom:34.5.0')
-    implementation 'com.google.firebase:firebase-analytics'
+    // Firebase platform BOM
+    implementation platform("com.google.firebase:firebase-bom:34.5.0")
+
+    // Firebase Analytics
+    implementation("com.google.firebase:firebase-analytics")
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,22 +7,31 @@ buildscript {
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.1.20"
     }
+
     repositories {
         google()
         mavenCentral()
     }
+
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        // Android Gradle Plugin
+        classpath("com.android.tools.build:gradle:8.5.2")
+
+        // React Native Gradle Plugin
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+
+        // Kotlin
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+
+        // Google Services plugin (Firebase)
+        classpath("com.google.gms:google-services:4.4.2")
     }
 }
 
 plugins {
-    // Add the dependency for the Google services Gradle plugin
-    id 'com.google.gms.google-services' version '4.4.4' apply false
-
+    id("com.android.application") version "8.5.0" apply false
+    id("com.facebook.react") version "0.76.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.20" apply false
 }
-
 
 apply plugin: "com.facebook.react.rootproject"

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,21 @@
-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
-plugins { id("com.facebook.react.settings") }
-extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
-rootProject.name = 'ToyLink'
-include ':app'
-includeBuild('../node_modules/@react-native/gradle-plugin')
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    includeBuild("../node_modules/@react-native/gradle-plugin")
+}
+
+plugins {
+    id("com.facebook.react.settings")
+}
+
+extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
+    ex.autolinkLibrariesFromCommand()
+}
+
+rootProject.name = "ToyLink"
+include(":app")
+
+includeBuild("../node_modules/@react-native/gradle-plugin")


### PR DESCRIPTION
## ✨ 작업 개요

<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
Android Gradle 설정 오류로 인해 앱이 빌드/실행되지 않는 문제를 해결했습니다.

## 📌 관련 이슈


## 📄 작업 내용
- `settings.gradle`에 `pluginManagement.repositories` 추가  
  → Google/Firebase 플러그인을 검색하지 못하던 문제 해결
- `android/build.gradle`
  - `google-services` 플러그인을 `plugins` 블록에서 제거
  - 대신 `classpath("com.google.gms:google-services:4.4.2")`로 정상 추가
  - AGP, Kotlin 플러그인 버전 명시
- `app/build.gradle`
  - `id("com.google.gms.google-services")` 플러그인을 올바른 위치에 적용
- Gradle 전체 버전 구조를 React Native 0.76 최신 템플릿에 맞게 재정비
- `./gradlew clean` 이후 `run-android` 정상 빌드 확인

## 📷 UI 스크린샷 (해당 시)

<!-- 전/후 비교 이미지 등 첨부 -->

## 💬 기타 사항

<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
